### PR TITLE
Updated module.json to be compatible with Foundry v11

### DIFF
--- a/module.json
+++ b/module.json
@@ -17,7 +17,7 @@
                 "type": "system",
                 "manifest": "https://github.com/StasTserk/foundry-burningwheel/blob/master/system.json",
                 "compatibility": {
-                    "verified": "1.3.1"
+                    "verified": "1.4.0"
                 }
             }
         ]
@@ -28,7 +28,7 @@
     "author": "PauloDeTiege",
     "url": "https://github.com/PauloDeTiege/FoundryBWCompendium",
     "manifest": "https://raw.githubusercontent.com/PauloDeTiege/FoundryBWCompendium/master/module.json",
-    "download": "https://github.com/PauloDeTiege/FoundryBWCompendium/archive/v0.1.13.zip",
+    "download": "https://github.com/PauloDeTiege/FoundryBWCompendium/archive/v0.1.14.zip",
     "bugs": "https://github.com/PauloDeTiege/FoundryBWCompendium/issues",
     "readme": "https://github.com/PauloDeTiege/FoundryBWCompendium/README.md",
     "packs": [
@@ -38,6 +38,7 @@
             "module": "foundry-bw-compendium",
             "system": "burningwheel",
             "path": "packs/common-skills.db",
+            "type": "Item",
             "entity": "Item"
         },
         {
@@ -46,6 +47,7 @@
             "module": "foundry-bw-compendium",
             "system": "burningwheel",
             "path": "packs/common-traits.db",
+            "type": "Item",
             "entity": "Item"
         },
         {
@@ -54,6 +56,7 @@
             "module": "foundry-bw-compendium",
             "system": "burningwheel",
             "path": "packs/dwarven-lifepaths.db",
+            "type": "Actor",
             "entity": "Actor"
         },
         {
@@ -62,6 +65,7 @@
             "module": "foundry-bw-compendium",
             "system": "burningwheel",
             "path": "packs/dwarven-traits.db",
+            "type": "Item",
             "entity": "Item"
         },
         {
@@ -70,6 +74,7 @@
             "module": "foundry-bw-compendium",
             "system": "burningwheel",
             "path": "packs/elven-lifepaths.db",
+            "type": "Actor",
             "entity": "Actor"
         },
         {
@@ -78,6 +83,7 @@
             "module": "foundry-bw-compendium",
             "system": "burningwheel",
             "path": "packs/elven-traits.db",
+            "type": "Item",
             "entity": "Item"
         },
         {
@@ -86,6 +92,7 @@
             "module": "foundry-bw-compendium",
             "system": "burningwheel",
             "path": "packs/human-lifepaths.db",
+            "type": "Actor",
             "entity": "Actor"
         },
         {
@@ -94,6 +101,7 @@
             "module": "foundry-bw-compendium",
             "system": "burningwheel",
             "path": "packs/melee-weapons.db",
+            "type": "Item",
             "entity": "Item"
         },
         {
@@ -102,6 +110,7 @@
             "module": "foundry-bw-compendium",
             "system": "burningwheel",
             "path": "packs/orcish-lifepaths.db",
+            "type": "Actor",
             "entity": "Actor"
         },
         {
@@ -110,6 +119,7 @@
             "module": "foundry-bw-compendium",
             "system": "burningwheel",
             "path": "packs/orc-traits.db",
+            "type": "Item",
             "entity": "Item"
         },
         {
@@ -118,6 +128,7 @@
             "module": "foundry-bw-compendium",
             "system": "burningwheel",
             "path": "packs/ranged-weapons.db",
+            "type": "Item",
             "entity": "Item"
         },
         {
@@ -126,6 +137,7 @@
             "module": "foundry-bw-compendium",
             "system": "burningwheel",
             "path": "packs/sorcery-spells.db",
+            "type": "Item",
             "entity": "Item"
         }
     ]


### PR DESCRIPTION
From what I tested, these are the only changes needed to make the module compatible with the new Foundry update. It will require a new release version, however (I took the liberty of updating the release number in the manifest following your scheme, to v0.1.14). I've also updated the version compatibility with the BW system to its latest release. This would resolve #34.